### PR TITLE
Fix pre-commit error on skipped branch

### DIFF
--- a/hooks/check_untracked_migrations.py
+++ b/hooks/check_untracked_migrations.py
@@ -16,7 +16,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     current_branch = get_current_branch()
     if args.branches and current_branch not in args.branches:
         print(f"{current_branch} is not present in --branches arg")
-        return 1
+        return 0
     found = False
     for filename in get_untracked_files():
         if re.match(r".*/migrations/.*\.py", filename):


### PR DESCRIPTION
Currently if a skipped branch is detected, the pre-commit run results in an error. For example:

```
Untracked Django migrations checker...........................................................Failed
- hook id: check-untracked-migrations
- exit code: 1
2-add-migrations-to-version-control is not present in --branches arg
```
It my understanding that this option is meant to ignore other branches and do not perform a check on them. Otherwise the `--branch` option does not seem to be useful.