### PR TITLE
Allow running on detached head

### DIFF
--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -11,5 +11,7 @@ def get_untracked_files() -> List[str]:
 
 
 def get_current_branch() -> str:
-    output = subprocess.check_output(BRANCH_CMD)
-    return output.decode().rstrip()
+    result = subprocess.run(BRANCH_CMD, stdout=subprocess.PIPE)
+    if result.returncode == 0:
+        return result.stdout.decode().rstrip()
+    return None

--- a/tests/check_untracked_migrations_test.py
+++ b/tests/check_untracked_migrations_test.py
@@ -1,3 +1,4 @@
+import subprocess
 from hooks.check_untracked_migrations import main
 from hooks.utils import get_current_branch
 
@@ -26,3 +27,10 @@ def test_running_on_incorrect_branch(temp_git_dir):
     with temp_git_dir.as_cwd():
         assert main(["--branches", "branch_one", "branch_two"]) == 1
 
+def test_running_on_detached_head_no_filter(temp_git_detached_dir):
+    with temp_git_detached_dir.as_cwd():
+        assert main() == 0
+
+def test_running_on_detached_head_with_filter(temp_git_detached_dir):
+    with temp_git_detached_dir.as_cwd():
+        assert main(["--branches", "branch_one", "branch_two"]) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,11 @@ def temp_git_dir(tmpdir):
     git_dir = tmpdir.join('gits')
     subprocess.call(['git', 'init', '--', str(git_dir)])
     yield git_dir
+
+@pytest.fixture
+def temp_git_detached_dir(tmpdir):
+    git_dir = tmpdir.join('gits')
+    subprocess.call(['git', 'init', '--', str(git_dir)])
+    subprocess.call(['git', 'commit', '--allow-empty', '-m', 'initial commit'], cwd=git_dir)
+    subprocess.call(['git', 'checkout', '--detach'], cwd=git_dir)
+    yield git_dir


### PR DESCRIPTION
This allows running on a detached head. This enables running this hook e.g. in "speculative-merge" CI job cases.
Previously:
```
Untracked Django migrations checker...........................................................Failed
- hook id: check-untracked-migrations
- exit code: 1

fatal: ref HEAD is not a symbolic ref
```