### PR TITLE
Python 3.7 is end of life

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.7 is no longer supported by the Python Core Team nor by any current version of Django.
* https://devguide.python.org/versions
* https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django